### PR TITLE
FIX: Issue node sass dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
+package-lock.json
+yarn.lock
 .cache/
 public

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gatsby-source-filesystem": "^2.8.1",
     "gatsby-transformer-sharp": "^2.9.0",
     "google-map-react": "^2.1.9",
-    "node-sass": "^5.0.0",
+    "node-sass": "^4.9.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^6.1.0",


### PR DESCRIPTION
gatsby-plugin-sass 2.8.0 ei suostunut asentumaan node-sass 5.0.0:n kanssa.

node-sass ^5.0.0 --> node-sass ^4.9.0